### PR TITLE
external/skia: Take Fast Jpeg Decoding Path

### DIFF
--- a/src/codec/SkJpegCodec.h
+++ b/src/codec/SkJpegCodec.h
@@ -14,6 +14,10 @@
 #include "SkStream.h"
 #include "SkTemplates.h"
 
+extern "C" {
+    #include "jpeglib.h"
+}
+
 class JpegDecoderMgr;
 
 /*
@@ -108,6 +112,16 @@ private:
                             bool needsCMYKToRGB);
     void allocateStorage(const SkImageInfo& dstInfo);
     int readRows(const SkImageInfo& dstInfo, void* dst, size_t rowBytes, int count, const Options&);
+
+    /*
+     * Categorize JPEG image dimension.
+     * Can be used to apply different settings for different sizes.
+     */
+    enum JpegDecodingSize: JDIMENSION {
+        kSmall_JpegDecodingSize = 400,
+        kMedium_JpegDecodingSize = 1600
+    };
+    static void setupJpegDecoding(jpeg_decompress_struct* dinfo);
 
     /*
      * Scanline decoding.


### PR DESCRIPTION
For smaller pictures, we use fast upsampler. To do so, we disable fancy
upsampler. However, when fancy upsampler disabled, libjpeg-turbo may
choose to use merged upsampler, causing unwanted behavior. We need to
make sure merged upsampler is disabled so that only fast upsampler will
be used. We only use fast upsampler for smaller pictures because the
visual difference(if there is any) will be even less noticeable.

Change-Id: Id4031df1d5cd2be566c1de8f345993ef8880dcc3
Signed-off-by: Jason Edson <jaysonedson@gmail.com>